### PR TITLE
ADES_POD_NODESELECTORS

### DIFF
--- a/charts/ades/README.md
+++ b/charts/ades/README.md
@@ -94,7 +94,8 @@ The configuration parameters in this section control the resources requested and
 | workflowExecutor.stageout.cwl             | Stage-out CWL workflow file path                                                                 | `charts/ades/files/cwl/stageout/terradue_stars_latest.cwl`                            |
 | workflowExecutor.rulez.cwl  | Data structure for defining the CWL parameter used by [`cwl-wrapper`](https://github.com/EOEPCA/cwl-wrapper) | `empty`  |
 | workflowExecutor.imagePullSecrets       | ImagePullSecrets is an optional list of references to secrets for the processing namespace to use for pulling any of the images used by the processing pods. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod                                                                                     | `[]`                            |
-|workflowExecutor.pod.env | Environmental variables in the pod context | `{}` |
+|workflowExecutor.pod.env | Environmental variables for the processing pods | `{}` |
+|workflowExecutor.pod.nodeSelector | Node selectors for the processing pods | `{}` |
 |workflowExecutor.userResourceManager | Enables resource manager | `false` |
 |workflowExecutor.resourceManagerEndpoint | Resource manager endpoint |`"https://resourcemanager-api.com"`|
 |workflowExecutor.resourceManagerWorkspacePrefix | Resource manager workspace prefix |`rm-user`|

--- a/charts/ades/templates/configmap.yaml
+++ b/charts/ades/templates/configmap.yaml
@@ -17,6 +17,6 @@ data:
   rulez.cwl: {{ required "A valid .Values.Values.workflowExecutor.rulez.cwl entry required!" (tpl (.Values.workflowExecutor.rulez.cwl) . | quote) }}
   wfinputs.yaml: {{ toYaml .Values.workflowExecutor.inputs | quote }}
   pod_env_vars.yaml: {{ toYaml .Values.workflowExecutor.pod.env | quote }}
-
+  pod_nodeselectors.yaml: {{ toYaml .Values.workflowExecutor.pod.nodeSelector | quote }}
 
   

--- a/charts/ades/templates/deployment.yaml
+++ b/charts/ades/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: /var/etc/ades/wfinputs.yaml
             - name: ADES_POD_ENV_VARS
               value: /var/etc/ades/pod_env_vars.yaml
+            - name: ADES_POD_NODESELECTORS
+              value: /var/etc/ades/pod_nodeselectors.yaml
             - name: STORAGE_CLASS
               value: {{ .Values.workflowExecutor.processingStorageClass | quote }}
             - name: VOLUME_TMP_SIZE

--- a/charts/ades/values.yaml
+++ b/charts/ades/values.yaml
@@ -232,6 +232,7 @@ workflowExecutor:
   pod:
     env: {}
     # HTTP_PROXY: http://1.2.3.4:8534
+    nodeSelector: {}
 
   useResourceManager: false
   resourceManagerEndpoint: "https://resourcemanager-api.com"


### PR DESCRIPTION
Add the options to pass ADES_POD_NODESELECTORS as a path to node selectors file that can be used with https://github.com/Duke-GCB/calrissian/pull/129 and https://github.com/EOEPCA/proc-workflow-executor/pull/3